### PR TITLE
[FEAT] 부품 조회 및 대리점 재고 관리 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.6'
-	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.springframework.boot' version '3.3.0'
+	id 'io.spring.dependency-management' version '1.1.5'
 }
 
 group = 'com.sampoom'
@@ -27,6 +27,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -34,10 +35,19 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // OpenFeign 추가
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
+    runtimeOnly 'org.postgresql:postgresql'
 
 	//Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.2"
+    }
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sampoom/backend/BackendApplication.java
+++ b/src/main/java/com/sampoom/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package com.sampoom.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients(basePackages = "com.sampoom.backend.api.part.feign")
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/sampoom/backend/api/agency/entity/Agency.java
+++ b/src/main/java/com/sampoom/backend/api/agency/entity/Agency.java
@@ -1,0 +1,25 @@
+package com.sampoom.backend.api.agency.entity;
+
+import com.sampoom.backend.common.entitiy.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "agency")
+public class Agency extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String location;
+
+}

--- a/src/main/java/com/sampoom/backend/api/agency/repository/AgencyRepository.java
+++ b/src/main/java/com/sampoom/backend/api/agency/repository/AgencyRepository.java
@@ -1,0 +1,7 @@
+package com.sampoom.backend.api.agency.repository;
+
+import com.sampoom.backend.api.agency.entity.Agency;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AgencyRepository  extends JpaRepository<Agency, Long> {
+}

--- a/src/main/java/com/sampoom/backend/api/part/controller/PartController.java
+++ b/src/main/java/com/sampoom/backend/api/part/controller/PartController.java
@@ -1,0 +1,54 @@
+package com.sampoom.backend.api.part.controller;
+
+import com.sampoom.backend.api.part.feign.dto.CategoryResponseDTO;
+import com.sampoom.backend.api.part.feign.dto.PartGroupResponseDTO;
+import com.sampoom.backend.api.part.feign.dto.PartResponseDTO;
+import com.sampoom.backend.api.part.service.PartService;
+import com.sampoom.backend.common.response.ApiResponse;
+import com.sampoom.backend.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Part", description = "대리점 전용 부품 조회 API")
+@RestController
+@RequestMapping("/api/agency/{agencyId}")
+@RequiredArgsConstructor
+public class PartController {
+
+    private final PartService partService;
+
+    @Operation(summary = "대리점 별 부품 카테고리 조회", description = "대리점 별 부품 카테고리 조회")
+    @GetMapping("/category")
+    public ResponseEntity<ApiResponse<List<CategoryResponseDTO>>> getCategories(@PathVariable Long agencyId) {
+        List<CategoryResponseDTO> categoryList = partService.getCategories(agencyId);
+        return ApiResponse.success(SuccessStatus.CATEGORY_LIST_SUCCESS, categoryList);
+    }
+
+    @Operation(summary = "대리점 별 카테고리 별 그룹 조회", description = "대리점 별 카테고리 별 그룹 조회")
+    @GetMapping("/category/{categoryId}")
+    public ResponseEntity<ApiResponse<List<PartGroupResponseDTO>>> getGroups(
+            @PathVariable Long agencyId,
+            @PathVariable Long categoryId
+    ) {
+        List<PartGroupResponseDTO> groupList = partService.getGroups(agencyId, categoryId);
+        return ApiResponse.success(SuccessStatus.GROUP_LIST_SUCCESS, groupList);
+    }
+
+    @Operation(summary = "대리점 별 부품 목록 조회 (그룹 기준)", description = "대리점 별 부품 목록 조회")
+    @GetMapping("/group/{groupId}")
+    public ResponseEntity<ApiResponse<List<PartResponseDTO>>> getParts(
+            @PathVariable Long agencyId,
+            @PathVariable Long groupId
+    ) {
+        List<PartResponseDTO> partList = partService.getParts(agencyId, groupId);
+        return ApiResponse.success(SuccessStatus.PART_LIST_SUCCESS, partList);
+    }
+}

--- a/src/main/java/com/sampoom/backend/api/part/feign/PartClient.java
+++ b/src/main/java/com/sampoom/backend/api/part/feign/PartClient.java
@@ -1,0 +1,30 @@
+package com.sampoom.backend.api.part.feign;
+
+import com.sampoom.backend.api.part.feign.dto.ApiResponse;
+import com.sampoom.backend.api.part.feign.dto.CategoryResponseDTO;
+import com.sampoom.backend.api.part.feign.dto.PartGroupResponseDTO;
+import com.sampoom.backend.api.part.feign.dto.PartResponseDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+// Part 서버의 REST API 호출용 클라이언트
+@FeignClient(name = "partClient", url = "http://3.38.218.173:8080/api/parts")
+public interface PartClient {
+
+    // 부품 카테고리 목록 조회
+    @GetMapping("/categories")
+    ApiResponse<List<CategoryResponseDTO>> getCategories();
+
+    // 카테고리별 그룹 목록 조회
+    @GetMapping("/categories/{categoryId}/groups")
+    ApiResponse<List<PartGroupResponseDTO>> getGroupsByCategory(@PathVariable("categoryId") Long categoryId);
+
+    // 그룹별 부품 목록 조회
+    @GetMapping
+    ApiResponse<List<PartResponseDTO>> getPartsByGroup(@RequestParam("groupId") Long groupId);
+}
+

--- a/src/main/java/com/sampoom/backend/api/part/feign/dto/ApiResponse.java
+++ b/src/main/java/com/sampoom/backend/api/part/feign/dto/ApiResponse.java
@@ -1,0 +1,14 @@
+package com.sampoom.backend.api.part.feign.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+// Part 서버 공통 응답 포맷 매핑용
+@Getter
+@Setter
+public class ApiResponse<T> {
+    private boolean success;
+    private int code;
+    private String message;
+    private T data;
+}

--- a/src/main/java/com/sampoom/backend/api/part/feign/dto/CategoryResponseDTO.java
+++ b/src/main/java/com/sampoom/backend/api/part/feign/dto/CategoryResponseDTO.java
@@ -1,0 +1,11 @@
+package com.sampoom.backend.api.part.feign.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CategoryResponseDTO {
+    private Long categoryId;
+    private String name;
+}

--- a/src/main/java/com/sampoom/backend/api/part/feign/dto/PartGroupResponseDTO.java
+++ b/src/main/java/com/sampoom/backend/api/part/feign/dto/PartGroupResponseDTO.java
@@ -1,0 +1,11 @@
+package com.sampoom.backend.api.part.feign.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PartGroupResponseDTO {
+    private Long groupId;
+    private String name;
+}

--- a/src/main/java/com/sampoom/backend/api/part/feign/dto/PartResponseDTO.java
+++ b/src/main/java/com/sampoom/backend/api/part/feign/dto/PartResponseDTO.java
@@ -1,0 +1,12 @@
+package com.sampoom.backend.api.part.feign.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PartResponseDTO {
+    private Long partId;
+    private String name;
+    private String code;
+}

--- a/src/main/java/com/sampoom/backend/api/part/service/PartService.java
+++ b/src/main/java/com/sampoom/backend/api/part/service/PartService.java
@@ -1,0 +1,40 @@
+package com.sampoom.backend.api.part.service;
+
+import com.sampoom.backend.api.part.feign.PartClient;
+import com.sampoom.backend.api.part.feign.dto.CategoryResponseDTO;
+import com.sampoom.backend.api.part.feign.dto.PartGroupResponseDTO;
+import com.sampoom.backend.api.part.feign.dto.PartResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PartService {
+
+    private final PartClient partClient;
+
+    // 부품 카테고리 목록 조회
+    public List<CategoryResponseDTO> getCategories(Long agencyId) {
+        return unwrap(partClient.getCategories());
+    }
+
+    // 카테고리 내 그룹 목록 조회
+    public List<PartGroupResponseDTO> getGroups(Long agencyId, Long categoryId) {
+        return unwrap(partClient.getGroupsByCategory(categoryId));
+    }
+
+    // 그룹 내 부품 목록 조회
+    public List<PartResponseDTO> getParts(Long agencyId, Long groupId) {
+        return unwrap(partClient.getPartsByGroup(groupId));
+    }
+
+    // 공통 응답 언랩 메서드
+    private static <T> T unwrap(com.sampoom.backend.api.part.feign.dto.ApiResponse<T> response) {
+        if (response == null || response.getData() == null) {
+            throw new IllegalStateException("Part 서버 응답이 비어 있습니다.");
+        }
+        return response.getData();
+    }
+}

--- a/src/main/java/com/sampoom/backend/api/stock/controller/StockController.java
+++ b/src/main/java/com/sampoom/backend/api/stock/controller/StockController.java
@@ -1,0 +1,59 @@
+package com.sampoom.backend.api.stock.controller;
+
+import com.sampoom.backend.api.stock.dto.StockInboundRequestDTO;
+import com.sampoom.backend.api.stock.dto.StockOutboundRequestDTO;
+import com.sampoom.backend.api.stock.dto.StockResponseDTO;
+import com.sampoom.backend.api.stock.service.StockService;
+import com.sampoom.backend.common.response.ApiResponse;
+import com.sampoom.backend.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Stock", description = "재고 API")
+@Slf4j
+@RestController
+@RequestMapping("/api/agency/{agencyId}/stocks")
+@RequiredArgsConstructor
+public class StockController {
+
+    private final StockService stockService;
+
+    @Operation(summary = "대리점 재고 목록 조회", description = "대리점의 전체 재고 목록을 조회")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<StockResponseDTO>>> getStocksByAgency(@PathVariable Long agencyId) {
+
+        // 서비스 호출해서 데이터 가져오기
+        List<StockResponseDTO> stockList = stockService.getStockList(agencyId);
+
+        return ApiResponse.success(SuccessStatus.STOCK_LIST_SUCCESS, stockList);
+    }
+
+    @Operation(summary = "대리점 재고 입고 처리", description = "대리점 재고 입고 처리")
+    @PostMapping("/inbound")
+    public ResponseEntity<ApiResponse<Void>> inboundStock(
+            @PathVariable Long agencyId,
+            @Valid @RequestBody StockInboundRequestDTO stockInboundRequestDTO
+    ) {
+        stockService.inboundStock(agencyId, stockInboundRequestDTO);
+
+        return ApiResponse.success(SuccessStatus.STOCK_INBOUND_SUCCESS, null);
+    }
+
+    @Operation(summary = "대리점 재고 출고 처리", description = "여러 부품 재고를 출고 처리")
+    @PostMapping("/outbound")
+    public ResponseEntity<ApiResponse<Void>> outboundStock(
+            @PathVariable Long agencyId,
+            @Valid @RequestBody StockOutboundRequestDTO stockOutboundRequestDTO
+    ) {
+        stockService.outboundStock(agencyId, stockOutboundRequestDTO);
+
+        return ApiResponse.success(SuccessStatus.STOCK_OUTBOUND_SUCCESS, null);
+    }
+}

--- a/src/main/java/com/sampoom/backend/api/stock/dto/StockAdjustRequestDTO.java
+++ b/src/main/java/com/sampoom/backend/api/stock/dto/StockAdjustRequestDTO.java
@@ -1,0 +1,19 @@
+package com.sampoom.backend.api.stock.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class StockAdjustRequestDTO {
+
+    @NotNull(message = "수정할 재고 수량은 필수입니다.")
+    @PositiveOrZero(message = "재고 수량은 0 이상이어야 합니다.") // 0개로 맞출 수도 있음
+    private Long finalQuantity;
+
+    private String reason;
+}

--- a/src/main/java/com/sampoom/backend/api/stock/dto/StockInboundRequestDTO.java
+++ b/src/main/java/com/sampoom/backend/api/stock/dto/StockInboundRequestDTO.java
@@ -1,0 +1,29 @@
+package com.sampoom.backend.api.stock.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class StockInboundRequestDTO {
+
+    private List<InboundItem> items;
+
+    @Getter
+    @NoArgsConstructor
+    public static class InboundItem {
+
+        @NotNull(message = "부품 ID는 필수입니다.")
+        private Long partId;
+
+        @NotNull(message = "출고 수량은 필수입니다.")
+        @Positive(message = "출고 수량은 0보다 커야 합니다.")
+        private int quantity;
+    }
+}

--- a/src/main/java/com/sampoom/backend/api/stock/dto/StockOutboundRequestDTO.java
+++ b/src/main/java/com/sampoom/backend/api/stock/dto/StockOutboundRequestDTO.java
@@ -1,0 +1,30 @@
+package com.sampoom.backend.api.stock.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class StockOutboundRequestDTO {
+
+    private List<StockItem> items;
+
+    @Getter
+    @NoArgsConstructor
+    public static class StockItem {
+
+        @NotNull(message = "부품 ID는 필수입니다.")
+        private Long partId;
+
+        @NotNull(message = "출고 수량은 필수입니다.")
+        @Positive(message = "출고 수량은 0보다 커야 합니다.")
+        private int quantity;
+    }
+}

--- a/src/main/java/com/sampoom/backend/api/stock/dto/StockResponseDTO.java
+++ b/src/main/java/com/sampoom/backend/api/stock/dto/StockResponseDTO.java
@@ -1,0 +1,23 @@
+package com.sampoom.backend.api.stock.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class StockResponseDTO {
+
+    private Long stockId;
+    private Long agencyId;
+    private Long partId;
+    private int quantity;
+    private String partName;
+    private String partCode;
+}

--- a/src/main/java/com/sampoom/backend/api/stock/entity/AgencyStock.java
+++ b/src/main/java/com/sampoom/backend/api/stock/entity/AgencyStock.java
@@ -1,0 +1,63 @@
+package com.sampoom.backend.api.stock.entity;
+
+import com.sampoom.backend.common.entitiy.BaseTimeEntity;
+import com.sampoom.backend.common.exception.BadRequestException;
+import com.sampoom.backend.common.response.ErrorStatus;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "agency_stock")
+public class AgencyStock extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long agencyId;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "agency_id")
+//    private Agency agency;
+
+    private Long partId;
+
+    private int quantity;
+
+    public void increaseQuantity(int quantity) {
+        this.quantity += quantity;
+    }
+
+    public void decreaseQuantity(int quantity) {
+        int restQuantity = this.quantity - quantity;
+        if (restQuantity < 0) {
+            throw new BadRequestException(ErrorStatus.STOCK_INSUFFICIENT.getMessage());
+        }
+        this.quantity = restQuantity;
+    }
+
+    public static AgencyStock create(Long agencyId, Long partId, int quantity) {
+        return AgencyStock.builder()
+                .agencyId(agencyId)
+                .partId(partId)
+                .quantity(quantity)
+                .build();
+    }
+
+    // 실제 Agency 연관관계 사용 시
+    // public static AgencyStock create(Agency agency, Long partId, int quantity) {
+    //     return AgencyStock.builder()
+    //             .agency(agency)
+    //             .partId(partId)
+    //             .quantity(quantity)
+    //             .build();
+    // }
+
+}

--- a/src/main/java/com/sampoom/backend/api/stock/repository/AgencyStockRepository.java
+++ b/src/main/java/com/sampoom/backend/api/stock/repository/AgencyStockRepository.java
@@ -1,0 +1,16 @@
+package com.sampoom.backend.api.stock.repository;
+
+import com.sampoom.backend.api.stock.entity.AgencyStock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AgencyStockRepository extends JpaRepository<AgencyStock, Long> {
+
+    // 특정 대리점의 재고 목록 조회
+    List<AgencyStock> findByAgencyId(Long agencyId);
+
+    // 특정 대리점의 partId로 재고를 찾음
+    Optional<AgencyStock> findByAgencyIdAndPartId(Long agencyId, Long partId);
+}

--- a/src/main/java/com/sampoom/backend/api/stock/service/StockService.java
+++ b/src/main/java/com/sampoom/backend/api/stock/service/StockService.java
@@ -1,0 +1,141 @@
+package com.sampoom.backend.api.stock.service;
+
+import com.sampoom.backend.api.part.feign.PartClient;
+import com.sampoom.backend.api.part.feign.dto.PartResponseDTO;
+import com.sampoom.backend.api.stock.dto.StockInboundRequestDTO;
+import com.sampoom.backend.api.stock.dto.StockOutboundRequestDTO;
+import com.sampoom.backend.api.stock.dto.StockResponseDTO;
+import com.sampoom.backend.api.stock.entity.AgencyStock;
+import jakarta.annotation.PostConstruct;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockService {
+
+//    private final AgencyStockRepository agencyStockRepository;
+//    private final AgencyRepository agencyRepository;
+    private final PartClient partClient;
+
+    // DB 대신 사용할 mock 데이터 저장소
+    private final Map<Long, AgencyStock> mockStockDB = new HashMap<>();
+
+    // 서버 시작 시 기본 mock 데이터 5개 생성
+    @PostConstruct
+    public void initMockData() {
+        for (long i = 1; i <= 10; i++) {
+            mockStockDB.put(i, AgencyStock.builder()
+                    .id(i)
+                    .agencyId(1L)
+                    .partId(i)
+                    .quantity(100 + (int) i)
+                    .build());
+        }
+    }
+
+    // 재고 목록 조회
+    @Transactional
+    public List<StockResponseDTO> getStockList(Long agencyId) {
+
+        // 임시 부품 리스트 저장
+        List<PartResponseDTO> allParts = new ArrayList<>();
+
+        // groupId 여러 개 돌려서 부품 데이터 긁어오기 (임시)
+        for (long groupId = 1; groupId <= 5; groupId++) {
+            try {
+                allParts.addAll(partClient.getPartsByGroup(groupId).getData());
+            } catch (Exception e) {
+                log.warn("Group {} 조회 실패: {}", groupId, e.getMessage());
+            }
+        }
+
+        // Map으로 변환해 빠르게 partId 매칭
+        Map<Long, PartResponseDTO> partMap = allParts.stream()
+                .collect(Collectors.toMap(PartResponseDTO::getPartId, p -> p, (a, b) -> a));
+
+        // mockStockDB 기준으로 재고 + 부품 정보 합침
+        return mockStockDB.values().stream()
+                .filter(stock -> stock.getAgencyId().equals(agencyId))
+                .map(stock -> {
+                    PartResponseDTO part = partMap.get(stock.getPartId());
+                    return StockResponseDTO.builder()
+                            .stockId(stock.getId())
+                            .agencyId(stock.getAgencyId())
+                            .partId(stock.getPartId())
+                            .quantity(stock.getQuantity())
+                            .partName(part != null ? part.getName() : "N/A")
+                            .partCode(part != null ? part.getCode() : "UNKNOWN")
+                            .build();
+                })
+                .toList();
+    }
+
+    // 재고 입고 처리
+    @Transactional
+    public void inboundStock(Long agencyId, StockInboundRequestDTO stockInboundRequestDTO) {
+
+        for (StockInboundRequestDTO.InboundItem item : stockInboundRequestDTO.getItems()) {
+
+            Optional<AgencyStock> existingStock = mockStockDB.values().stream()
+                    .filter(s -> s.getAgencyId().equals(agencyId) && s.getPartId().equals(item.getPartId()))
+                    .findFirst();
+
+            if (existingStock.isPresent()) {
+                existingStock.get().increaseQuantity(item.getQuantity());
+            } else {
+                long newId = mockStockDB.size() + 1L;
+                mockStockDB.put(newId, AgencyStock.builder()
+                        .id(newId)
+                        .agencyId(agencyId)
+                        .partId(item.getPartId())
+                        .quantity(item.getQuantity())
+                        .build());
+            }
+        }
+
+//        // 대리점 존재 여부 확인
+//        Agency agency = agencyRepository.findById(agencyId)
+//                .orElseThrow(() -> new NotFoundException(ErrorStatus.AGENCY_NOT_FOUND.getMessage()));
+//
+//        for (StockInboundRequestDTO.InboundItem item : stockInboundRequestDTO.getItems()) {
+//            // 해당 대리점에 해당 부품 재고가 이미 있는지 확인
+//            Optional<AgencyStock> optionalAgencyStock = agencyStockRepository.findByAgencyIdAndPartId(agencyId, stockInboundRequestDTO.getPartId());
+//
+//            if (optionalAgencyStock.isPresent()) {
+//                // 이미 재고가 있으면 기존 재고 수량 증가
+//                AgencyStock existingStock = optionalAgencyStock.get();
+//                existingStock.increaseQuantity(stockInboundRequestDTO.getQuantity());
+//            } else {
+//                // 재고가 없으면 새로운 재고 생성
+//                AgencyStock newStock = AgencyStock.create(agency.getId(), stockInboundRequestDTO.getPartId(), stockInboundRequestDTO.getQuantity());
+//                agencyStockRepository.save(newStock);
+//            }
+//        }
+    }
+
+    // 재고 출고 처리 (장바구니 기능)
+    @Transactional
+    public void outboundStock(Long agencyId, StockOutboundRequestDTO stockOutboundRequestDTO) {
+
+        for (StockOutboundRequestDTO.StockItem item : stockOutboundRequestDTO.getItems()) {
+            mockStockDB.values().stream()
+                    .filter(s -> s.getAgencyId().equals(agencyId) && s.getPartId().equals(item.getPartId()))
+                    .findFirst()
+                    .ifPresent(stock -> stock.decreaseQuantity(item.getQuantity()));
+        }
+
+//        for (StockOutboundRequestDTO.StockItem item : stockOutboundRequestDTO.getItems()) {
+//            AgencyStock stock = agencyStockRepository.findByAgencyIdAndPartId(agencyId, item.getPartId())
+//                    .orElseThrow(() -> new NotFoundException(ErrorStatus.STOCK_NOT_FOUND.getMessage()));
+//
+//            stock.decreaseQuantity(item.getQuantity());
+//        }
+    }
+}

--- a/src/main/java/com/sampoom/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/sampoom/backend/common/response/ErrorStatus.java
@@ -13,7 +13,7 @@ public enum ErrorStatus {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     MISSING_EMAIL_VERIFICATION_EXCEPTION(HttpStatus.BAD_REQUEST, "이메일 인증을 진행해주세요."),
     ALREADY_REGISTER_EMAIL_EXCEPETION(HttpStatus.BAD_REQUEST, "이미 가입된 이메일 입니다."),
-
+    STOCK_INSUFFICIENT(HttpStatus.BAD_REQUEST, "재고 수량이 부족합니다."),
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
@@ -23,6 +23,9 @@ public enum ErrorStatus {
 
     // 404 NOT_FOUND
     NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+    STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 재고를 찾을 수 없습니다."),
+    AGENCY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 대리점을 찾을 수 없습니다."),
+    PART_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 부품을 찾을 수 없습니다."),
 
 
 

--- a/src/main/java/com/sampoom/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/sampoom/backend/common/response/SuccessStatus.java
@@ -11,7 +11,25 @@ public enum SuccessStatus {
 
     // 공통 성공 메시지
     OK(HttpStatus.OK, "요청이 성공적으로 처리되었습니다."),
-    CREATED(HttpStatus.CREATED, "리소스가 성공적으로 생성되었습니다.")
+    CREATED(HttpStatus.CREATED, "리소스가 성공적으로 생성되었습니다."),
+
+    // 재고 관련
+    STOCK_LIST_SUCCESS(HttpStatus.OK, "재고 목록 조회 성공"),
+    STOCK_INBOUND_SUCCESS(HttpStatus.OK, "재고 입고 처리 성공"),
+    STOCK_OUTBOUND_SUCCESS(HttpStatus.OK, "재고 출고 처리 성공"),
+    STOCK_ADJUST_SUCCESS(HttpStatus.OK, "재고 수량 조정 성공"),
+
+    // 대리점 관련
+    AGENCY_LIST_SUCCESS(HttpStatus.OK, "대리점 목록 조회 성공"),
+    AGENCY_DETAIL_SUCCESS(HttpStatus.OK, "대리점 상세 조회 성공"),
+
+    CART_ADD_SUCCESS(HttpStatus.OK,  "장바구니 담기 성공"),
+    CART_LIST_SUCCESS(HttpStatus.OK, "장바구니 조회 성공"),
+    CART_CLEAR_SUCCESS(HttpStatus.OK, "장바구니 초기화 성공"),
+
+    CATEGORY_LIST_SUCCESS(HttpStatus.OK, "카테고리 목록 조회 성공"),
+    GROUP_LIST_SUCCESS(HttpStatus.OK, "그룹 목록 조회 성공"),
+    PART_LIST_SUCCESS(HttpStatus.OK, "부품 목록 조회 성공"),
     ;
 
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #3 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 부품 서버 연동 후 부품 조회 기능 구현 
- 대리점 재고 기능 임시 구현

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- Part 서버 직접 호출 중

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 대리점별 부품 카테고리·그룹·부품 목록 조회 API 추가
  - 대리점 재고 조회, 입고, 출고 API 추가
  - 표준 응답 포맷 도입 및 성공/오류 상태 코드 확장
  - 요청 데이터 유효성 검증 강화(필수 값, 수량 범위)

- Chores
  - 원격 부품 서비스 연동을 위한 클라이언트 추가
  - 데이터 저장소 연동을 위한 엔티티/리포지토리 기반 마련
  - API 문서화를 위한 주석 보강

<!-- end of auto-generated comment: release notes by coderabbit.ai -->